### PR TITLE
fix: ka-396 (run mode consumer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ logs/
 .vscode
 .env
 __pycache__
+.project
+.settings/
+.classpath

--- a/agent-plane/agent-plane-protocol/pom.xml
+++ b/agent-plane/agent-plane-protocol/pom.xml
@@ -162,6 +162,32 @@
             <version>${edc.version}</version>
         </dependency>
 
+
+        <!-- Jersey Test -->
+        <dependency>
+            <groupId>org.eclipse.edc</groupId>
+            <artifactId>jersey-core</artifactId>
+            <version>${edc.version}</version>
+            <classifier>test-fixtures</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- EDC Test -->
+        <dependency>
+            <groupId>org.eclipse.edc</groupId>
+            <artifactId>junit</artifactId>
+            <version>${edc.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- EDC Test -->
+        <dependency>
+            <groupId>org.eclipse.edc</groupId>
+            <artifactId>json-ld</artifactId>
+            <version>${edc.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Controller Annotations -->
         <dependency>
             <groupId>jakarta.ws.rs</groupId>

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/AgentController.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/AgentController.java
@@ -397,7 +397,16 @@ public class AgentController {
         }
 
         if(remoteUrl!=null) {
-            return delegationService.executeQueryRemote(remoteUrl,skill,graph, headers, request, response, uri);
+        	// we need to delegate to the agent under remote URL 
+        	DelegationResponse intermediateResponse = delegationService.executeQueryRemote(remoteUrl,skill,graph, headers, request, response, uri);
+        	// in case runMode = provider the response already contains the final result
+        	if (intermediateResponse.getQueryString() == null) {
+        		return intermediateResponse.getResponse();
+        	} else {
+        		// in case runMode = consumer we set the skill text to the downloaded text and advance 
+        		skill = intermediateResponse.getQueryString();
+        		asset = null;
+        	}
         }
 
         try {

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/DelegationResponse.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/DelegationResponse.java
@@ -1,0 +1,69 @@
+// Copyright (c) 2023 T-Systems International GmbH
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.tractusx.agents.edc.http;
+
+import jakarta.ws.rs.core.Response;
+
+/**
+ * A wrapper around the response of a 
+ * call to another agent in the dataspace
+ * Depending on the run mode (provider/consumer), 
+ * this response could optionally host the text of 
+ * a skill to be executed locally. 
+ */
+public class DelegationResponse {
+	
+	final protected String queryString;
+	
+	final protected Response response;
+	
+	/**
+	 * Construct a new wrapper response for runMode = consumer
+	 * @param queryString downloaded text of the skill
+	 * @param response the response Object to return
+	 */
+	public DelegationResponse(String queryString, Response response) {
+		this.queryString = queryString;
+		this.response = response;
+	}
+	
+	/**
+	 * Construct a new wrapper response for runMode = provider
+	 * @param response the response Object to return
+	 */
+	public DelegationResponse(Response response) {
+		this.response = response;
+		this.queryString = null;
+	}
+
+	/**
+	 * @return downloaded text of skill (should be not null if runMode = consumer)
+	 */
+	public String getQueryString() {
+		return queryString;
+	}
+
+	/**
+	 * @return the response Object to return (should be not null in  each case)
+	 */
+	public Response getResponse() {
+		return response;
+	}
+	
+
+}

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/IDelegationService.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/IDelegationService.java
@@ -37,7 +37,7 @@ public interface IDelegationService {
      * @param request url request
      * @param response final response
      * @param uri original uri
-     * @return an intermediate response (the actual result will be put into the final response state)
+     * @return an intermediate response which may contain a textual skill to be executed locally otherwise the actual result has already been put into the final response's state
      */
-    Response executeQueryRemote(String remoteUrl, String skill, String graph, HttpHeaders headers, HttpServletRequest request, HttpServletResponse response, UriInfo uri);
+    DelegationResponse executeQueryRemote(String remoteUrl, String skill, String graph, HttpHeaders headers, HttpServletRequest request, HttpServletResponse response, UriInfo uri);
 }

--- a/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
+++ b/agent-plane/agent-plane-protocol/src/main/java/org/eclipse/tractusx/agents/edc/http/transfer/AgentSource.java
@@ -100,9 +100,9 @@ public class AgentSource implements DataSource {
                 SkillDistribution distribution=skillStore.getDistribution(asset);
                 String params=request.getProperties().get(AgentSourceHttpParamsDecorator.QUERY_PARAMS);
                 SkillDistribution runMode=SkillDistribution.ALL;
-                if(params.contains("runMode=provider")) {
+                if(params.contains("runMode=provider") || params.contains("runMode=PROVIDER")) {
                     runMode=SkillDistribution.PROVIDER;
-                } else if(params.contains("runMode=consumer")) {
+                } else if(params.contains("runMode=consumer") || params.contains("runMode=CONSUMER")) {
                     runMode=SkillDistribution.CONSUMER;
                 }
                 if(runMode==SkillDistribution.CONSUMER) {
@@ -113,7 +113,7 @@ public class AgentSource implements DataSource {
                 } else if(runMode==SkillDistribution.PROVIDER && distribution==SkillDistribution.CONSUMER) {
                     return StreamResult.error(String.format("Run distribution of skill %s should be provider, but was set to consumer only.", asset));
                 }
-                skill=skillText.get();
+                skill=skillText.get(); // default execution for runMode=ALL or runMode=provider and DistributionMode is ALL or provider
             }
         }
         try (Response response = processor.execute(this.requestFactory.toRequest(params),skill,graph,request.getSourceDataAddress().getProperties())) {

--- a/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/MockAgreementController.java
+++ b/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/MockAgreementController.java
@@ -21,16 +21,51 @@ import org.eclipse.edc.spi.types.domain.edr.EndpointDataReference;
 
 /**
  * mock agreement controller for testing purposes
+ * It will "fake" an agreement endpoint that will finally
+ * hit the given path/port on localhost
  */
 public class MockAgreementController implements IAgreementController {
 
+    String path;
+    int port;
+
+    /**
+     * specific mock controller
+     * @param path path of endpoint
+     * @param port port of endpoint
+     */
+    public MockAgreementController(String path, int port) {
+        this.path=path;
+        this.port=port;
+    }
+
+    /**
+     * default mock controller
+     */
+    public MockAgreementController() {
+        this.path="sparql";
+        this.port=8080;
+    }
+
+    /**
+     * create a faked endpoint reference
+     * @param assetId id of the asset
+     * @return a data reference pointing to the internal endpoint
+     */
     @Override
     public EndpointDataReference get(String assetId) {
         EndpointDataReference.Builder builder= EndpointDataReference.Builder.newInstance();
-        builder.endpoint("http://localhost:8080/sparql#"+assetId);
+        builder.endpoint(String.format("http://localhost:%d/%s#%s",port,path,assetId));
         return builder.build();
     }
 
+    /**
+     * negotiation case, delegates to get
+     * @param remoteUrl the connector
+     * @param asset id of the asset
+     * @return a data reference pointing to the internal endpoint
+     * @throws WebApplicationException in case something goes wrong
+     */
     @Override
     public EndpointDataReference createAgreement(String remoteUrl, String asset) throws WebApplicationException {
         return get(asset);

--- a/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/http/TestController.java
+++ b/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/http/TestController.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.tractusx.agents.edc.http;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+
+/**
+ * A controller that simulates remoting capabilities
+ */
+@Path("/test")
+public class TestController {
+
+    /**
+     * @return a remote skill
+     */
+    @GET
+    @Produces("application/sparql-query")
+    public String getSkill(@QueryParam("asset") String asset) {
+        return "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?what WHERE { VALUES (?what) { (\"42\"^^xsd:int)} }";
+    }
+}

--- a/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/sparql/TestSparqlProcessor.java
+++ b/agent-plane/agent-plane-protocol/src/test/java/org/eclipse/tractusx/agents/edc/sparql/TestSparqlProcessor.java
@@ -1,0 +1,319 @@
+// Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.eclipse.tractusx.agents.edc.sparql;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.*;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
+import org.eclipse.edc.spi.monitor.ConsoleMonitor;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.tractusx.agents.edc.*;
+import org.eclipse.tractusx.agents.edc.rdf.RDFStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the sparql processor
+ */
+public class TestSparqlProcessor {
+    
+    ConsoleMonitor monitor=new ConsoleMonitor();
+    TestConfig config=new TestConfig();
+    AgentConfig agentConfig=new AgentConfig(monitor,config);
+    ServiceExecutorRegistry serviceExecutorReg=new ServiceExecutorRegistry();
+    OkHttpClient client=new OkHttpClient();
+    IAgreementController mockController = new MockAgreementController();
+    ExecutorService threadedExecutor= Executors.newSingleThreadExecutor();
+    TypeManager typeManager = new TypeManager();
+    DataspaceServiceExecutor exec=new DataspaceServiceExecutor(monitor,mockController,agentConfig,client,threadedExecutor,typeManager);
+    RDFStore store = new RDFStore(agentConfig,monitor);
+
+    SparqlQueryProcessor processor=new SparqlQueryProcessor(serviceExecutorReg,monitor,agentConfig,store, typeManager);
+
+    AutoCloseable mocks=null;
+
+    @BeforeEach
+    public void setUp()  {
+        mocks=MockitoAnnotations.openMocks(this);
+        //serviceExecutorReg.add(exec);
+        serviceExecutorReg.addBulkLink(exec);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if(mocks!=null) {
+            mocks.close();
+            mocks=null;
+            serviceExecutorReg.remove(exec);
+            serviceExecutorReg.removeBulkLink(exec);
+        }
+    }
+
+    ObjectMapper mapper=new ObjectMapper();
+
+    /**
+     * test federation call - will only work with a local oem provider running
+     * @throws IOException in case of an error
+     */
+    @Test
+    @Tag("online")
+    public void testFederatedGraph() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?what WHERE { SERVICE<edc://localhost:8080/sparql> { " +
+                "GRAPH <urn:cx:Graph:4711> { VALUES (?what) { (\"42\"^^xsd:int)} } } }";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.addHeader("Accept","application/json");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        try (Response response=processor.execute(builder.build(),null,null,Map.of())) {
+            JsonNode root = mapper.readTree(Objects.requireNonNull(response.body()).string());
+            JsonNode whatBinding0 = root.get("results").get("bindings").get(0).get("what");
+            assertEquals("42", whatBinding0.get("value").asText(), "Correct binding");
+        }
+    }
+
+    /**
+     * test federation call - will only work with a local oem provider running
+     * @throws IOException in case of an error
+     */
+    @Test
+    @Tag("online")
+    public void testFederatedServiceChain() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?what WHERE { VALUES (?chain1) { (<http://localhost:8080/sparql#urn:cx:Graph:1>)} SERVICE ?chain1 { " +
+                "VALUES (?chain2) { (<http://localhost:8080/sparql>)} SERVICE ?chain2 { VALUES (?what) { (\"42\"^^xsd:int)} } } }";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.addHeader("Accept","application/sparql-results+json");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        try(Response response=processor.execute(builder.build(),null,null,Map.of())) {
+            assertTrue(response.isSuccessful(), "Response was successful");
+            JsonNode root = mapper.readTree(Objects.requireNonNull(response.body()).string());
+            JsonNode whatBinding0 = root.get("results").get("bindings").get(0).get("what");
+            assertEquals("84", whatBinding0.get("value").asText(), "Correct binding");
+        }
+    }
+
+    /**
+     * test remote call with non-existing target
+     * @throws IOException in case of an error
+     */
+    @Test
+    public void testRemoteError() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?what WHERE { SERVICE <http://does-not-resolve/sparql#urn:cx:Graph:1> { VALUES (?what) { (\"42\"^^xsd:int) } } }";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.addHeader("Accept","application/sparql-results+json");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        try(Response response=processor.execute(builder.build(),null,null,Map.of())) {
+            assertTrue(response.isSuccessful(), "Response was successful");
+            JsonNode root = mapper.readTree(Objects.requireNonNull(response.body()).string());
+            assertEquals(0, root.get("results").get("bindings").size());
+            String warnings = response.header("cx_warnings");
+            JsonNode warningsJson = mapper.readTree(warnings);
+            assertEquals(1, warningsJson.size(), "got remote warnings");
+        }
+    }
+
+    /**
+     * test remote call with matchmaking agent
+     * @throws IOException in case of an error
+     */
+    @Test
+    @Tag("online")
+    public void testRemoteWarning() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?what WHERE { SERVICE <http://localhost:8898/match?asset=urn%3Acx%3AGraphAsset%23Test> { VALUES (?what) { (\"42\"^^xsd:int) } } }";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.addHeader("Accept","application/sparql-results+json");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        try(Response response=processor.execute(builder.build(),null,null,Map.of())) {
+            assertTrue(response.isSuccessful(), "Response was successful");
+            JsonNode root = mapper.readTree(Objects.requireNonNull(response.body()).string());
+            assertEquals(1, root.get("results").get("bindings").size());
+            String warnings = response.header("cx_warnings");
+            JsonNode warningsJson = mapper.readTree(warnings);
+            assertEquals(1, warningsJson.size(), "got remote warnings");
+        }
+    }
+
+    /**
+     * test remote call with matchmaking agent
+     * @throws IOException in case of an error
+     */
+    @Test
+    @Tag("online")
+    public void testRemoteTransfer() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT ?what WHERE { SERVICE <http://localhost:8898/transfer?asset=urn%3Acx%3AGraphAsset%23Test> { VALUES (?what) { (\"42\"^^xsd:int) } } }";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.addHeader("Accept","application/sparql-results+json");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        try (Response response=processor.execute(builder.build(),null,null,Map.of())) {
+            assertTrue(response.isSuccessful(), "Response was successful");
+            JsonNode root = mapper.readTree(Objects.requireNonNull(response.body()).string());
+            assertEquals(1, root.get("results").get("bindings").size());
+            String warnings = response.header("cx_warnings");
+            JsonNode warningsJson = mapper.readTree(warnings);
+            assertEquals(1, warningsJson.size(), "got remote warnings");
+        }
+    }
+
+    /**
+     * test federation call - will only work with a local oem provider running
+     * @throws IOException in case of an error
+     */
+    @Test
+    @Tag("online")
+    public void testBatchFederation() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> "+
+                "SELECT ?chain1 ?what ?output WHERE { " +
+                "  VALUES (?chain1 ?what) { "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:1> \"42\"^^xsd:int) "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:2> \"21\"^^xsd:int) "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:1> \"84\"^^xsd:int) "+
+                "  } "+
+                "  SERVICE ?chain1 { " +
+                "    BIND(?what as ?output) "+
+                "  } "+
+                "}";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.addHeader("Accept","application/sparql-results+json");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        try (Response response=processor.execute(builder.build(),null,null,Map.of())) {
+            assertTrue(response.isSuccessful(), "Successful result");
+            JsonNode root = mapper.readTree(Objects.requireNonNull(response.body()).string());
+            JsonNode bindings = root.get("results").get("bindings");
+            assertEquals(3, bindings.size(), "Correct number of result bindings.");
+            JsonNode whatBinding0 = bindings.get(0).get("output");
+            assertEquals("21", whatBinding0.get("value").asText(), "Correct binding");
+            JsonNode whatBinding1 = bindings.get(1).get("output");
+            assertEquals("42", whatBinding1.get("value").asText(), "Correct binding");
+            JsonNode whatBinding2 = bindings.get(2).get("output");
+            assertEquals("84", whatBinding2.get("value").asText(), "Correct binding");
+        }
+    }
+
+
+    /**
+     * test not allowed calls
+     * @throws IOException in case of an error
+     */
+    @Test
+    public void testNotAllowedService() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> "+
+                "SELECT ?chain1 ?what ?output WHERE { " +
+                "  VALUES (?chain1 ?what) { "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:1> \"42\"^^xsd:int) "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:2> \"21\"^^xsd:int) "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:1> \"84\"^^xsd:int) "+
+                "  } "+
+                "  SERVICE ?chain1 { " +
+                "    BIND(?what as ?output) "+
+                "  } "+
+                "}";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.addHeader("Accept","application/sparql-results+json");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        try (Response response=processor.execute(builder.build(),null,null,Map.of(DataspaceServiceExecutor.ALLOW_SYMBOL.getSymbol(),"https://.*"))) {
+            assertTrue(response.isSuccessful(), "Successful result");
+            JsonNode root = mapper.readTree(Objects.requireNonNull(response.body()).string());
+            JsonNode bindings = root.get("results").get("bindings");
+            assertEquals(0, bindings.size(), "Correct number of result bindings.");
+            JsonNode warnings = mapper.readTree(response.header("cx_warnings", "[]"));
+            assertTrue(warnings.isArray(), "Got a warnings array");
+            assertEquals(warnings.size(), 2, "Got correct service warnings number");
+        }
+    }
+
+    /**
+     * test not allowed calls
+     * @throws IOException in case of an error
+     */
+    @Test
+    public void testDeniedService() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> "+
+                "SELECT ?chain1 ?what ?output WHERE { " +
+                "  VALUES (?chain1 ?what) { "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:1> \"42\"^^xsd:int) "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:2> \"21\"^^xsd:int) "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:1> \"84\"^^xsd:int) "+
+                "  } "+
+                "  SERVICE ?chain1 { " +
+                "    BIND(?what as ?output) "+
+                "  } "+
+                "}";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.addHeader("Accept","application/sparql-results+json");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        try(Response response=processor.execute(builder.build(),null,null,Map.of(DataspaceServiceExecutor.DENY_SYMBOL.getSymbol(),"http://localhost.*"))) {
+            assertTrue(response.isSuccessful(), "Successful result");
+            JsonNode root = mapper.readTree(Objects.requireNonNull(response.body()).string());
+            JsonNode bindings = root.get("results").get("bindings");
+            assertEquals(0, bindings.size(), "Correct number of result bindings.");
+            JsonNode warnings = mapper.readTree(response.header("cx_warnings", "[]"));
+            assertTrue(warnings.isArray(), "Got a warnings array");
+            assertEquals(warnings.size(), 2, "Got correct service warnings number");
+        }
+    }
+
+     /**
+     * test standard allowance
+     * @throws IOException in case of an error
+     */
+    @Test
+    public void testDefaultService() throws IOException {
+        String query="PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> "+
+                "SELECT ?chain1 ?what ?output WHERE { " +
+                "  VALUES (?chain1 ?what) { "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:1> \"42\"^^xsd:int) "+
+                "   (<https://query.wikidata.org/sparql> \"21\"^^xsd:int) "+
+                "   (<http://localhost:8080/sparql#urn:cx:Graph:1> \"84\"^^xsd:int) "+
+                "  } "+
+                "  SERVICE ?chain1 { " +
+                "    BIND(?what as ?output) "+
+                "  } "+
+                "}";
+        Request.Builder builder=new Request.Builder();
+        builder.url("http://localhost:8080");
+        builder.addHeader("Accept","application/sparql-results+json");
+        builder.put(RequestBody.create(query, MediaType.parse("application/sparql-query")));
+        try (Response response=processor.execute(builder.build(),null,null,Map.of())) {
+            assertTrue(response.isSuccessful(), "Successful result");
+            JsonNode root = mapper.readTree(Objects.requireNonNull(response.body()).string());
+            JsonNode bindings = root.get("results").get("bindings");
+            assertEquals(1, bindings.size(), "Correct number of result bindings.");
+            JsonNode warnings = mapper.readTree(response.header("cx_warnings", "[]"));
+            assertTrue(warnings.isArray(), "Got a warnings array");
+            assertEquals(warnings.size(), 1, "Got correct service warnings number");
+        }
+    }
+
+}


### PR DESCRIPTION
<!--
 * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Apache License, Version 2.0 which is available at
 * https://www.apache.org/licenses/LICENSE-2.0.
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 * License for the specific language governing permissions and limitations
 * under the License.
 *
 * SPDX-License-Identifier: Apache-2.0
-->

## WHAT

Implements a lacking code path/shortcut when interacting with the DelegationService.
Tests the lacking code path.

## WHY

Remote Skill Execution was not possible, see https://github.com/eclipse-tractusx/knowledge-agents-edc/issues/69

## FURTHER NOTES
